### PR TITLE
Fix missing branch error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,7 @@ WORKING_BRANCH=("skills_py" "tactics_py" "plays_py")
 
 for i in ${WORKING_BRANCH[@]}; do
 	cd $i
-	git checkout Working
+	git checkout Working || (git checkout -b Working && git pull origin Working)
 	cd ..
 done
 


### PR DESCRIPTION
`checkout` not working as branch is missing in clone.